### PR TITLE
Implement character popup and application handling

### DIFF
--- a/src/components/common/ActionHub/ActionHub.jsx
+++ b/src/components/common/ActionHub/ActionHub.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from 'react';
 import Select from 'react-select';
 import Form from '../Form/Form';
 import { AuthContext } from '../../../context/AuthContext';
+import CharPopup from '../Form/CharPopup';
 
 const ActionHub = ({ onCreateAd, onFilterChange }) => {
     const [activeMode, setActiveMode] = useState('filter');
@@ -9,6 +10,8 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
     const [creatures, setCreatures] = useState([]);
     const [selectedBoss, setSelectedBoss] = useState(null);
     const [selectedWorld, setSelectedWorld] = useState('');
+    const [charInfo, setCharInfo] = useState(null);
+    const [showCharPopup, setShowCharPopup] = useState(false);
     const { user, login } = useContext(AuthContext);
     
 
@@ -66,6 +69,8 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
             setSelectedBoss(null);
             setSelectedWorld('');
             onFilterChange({ boss: '', world: '' });
+            setShowCharPopup(true);
+            return;
         }
         setActiveMode(mode);
     };
@@ -76,6 +81,13 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
         setSelectedWorld(newAd.world);
         setSelectedBoss(null);
         onFilterChange({ boss: '', world: newAd.world });
+        setCharInfo(null);
+    };
+
+    const handleCharSubmit = (info) => {
+        setCharInfo(info);
+        setShowCharPopup(false);
+        setActiveMode('create');
     };
 
     const baseStyle = "py-2 px-6 font-bold transition-all duration-300";
@@ -128,8 +140,15 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
 
                 {activeMode === 'create' && (
                     <div className="bg-transparent rounded-b-lg">
-                        <Form onCreateAd={handleCreateAd} onWorldSelect={(world) => onFilterChange({ boss: '', world })} />
+                        <Form
+                            onCreateAd={handleCreateAd}
+                            onWorldSelect={(world) => onFilterChange({ boss: '', world })}
+                            charInfo={charInfo}
+                        />
                     </div>
+                )}
+                {showCharPopup && (
+                    <CharPopup onSubmit={handleCharSubmit} onClose={() => setShowCharPopup(false)} />
                 )}
             </div>
         </div>

--- a/src/components/common/Card/Card.jsx
+++ b/src/components/common/Card/Card.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import crystalCoinIcon from '../../../assets/Crystal_Coin.gif';
 import MarkStarIcon from '../../../assets/mark-star-icon.svg?react';
-import SearchIconCards from '../../../assets/search-icon-cards.svg?react'
+import SearchIconCards from '../../../assets/search-icon-cards.svg?react';
 import DetailsPopup from './DetailsPopup';
+import CharPopup from '../Form/CharPopup';
+import { applyToAd } from '../../../firebase/firestoreService';
 // import tilesBossIcon from '../../../assets/tiles-icon.png'
 
 const handleFavoriteClick = () => {
@@ -19,9 +21,19 @@ const roleIcons = {
 
 const Card = ({ adData }) => {
     const [showPopup, setShowPopup] = useState(false);
+    const [showApply, setShowApply] = useState(false);
+    const [party, setParty] = useState(adData.party || []);
 
     const handleSearchClick = () => {
         setShowPopup(true);
+    };
+
+    const handleApply = async (info) => {
+        await applyToAd(adData.id, info, adData.approvalRequired);
+        if (!adData.approvalRequired) {
+            setParty(prev => [...prev, info]);
+        }
+        setShowApply(false);
     };
 
     return (
@@ -54,15 +66,14 @@ const Card = ({ adData }) => {
                         <p className='text-white mt-auto mb-auto'>{adData.value}</p>
                     </div>
                     <div className='flex flex-row gap-2'>
-                        {adData.roles.map((role, idx) => (
+                        {party.map((p, idx) => (
                             <img
                                 key={idx}
-                                src={role.icon ?? roleIcons[role.name]}
-                                alt=""
-                                className="w-[45px] h-[45px]"
+                                src={roleIcons[p.vocation]}
+                                alt=''
+                                className='w-[45px] h-[45px]'
                             />
                         ))}
-                        {/* <img src={tilesBossIcon} /> */}
                     </div>
                     <div className='flex flex-row overflow-hidden w-full justify-between gap-6'>
                         <SearchIconCards
@@ -74,9 +85,14 @@ const Card = ({ adData }) => {
                             <DetailsPopup onClose={() => setShowPopup(false)} />
                         )}
 
-                        <button className='w-full h-[30px] rounded-[8px] bg-[#A8C090] mt-auto text-black'>
+                        <button
+                            onClick={() => setShowApply(true)}
+                            className='w-full h-[30px] rounded-[8px] bg-[#A8C090] mt-auto text-black'>
                             Aplicar
                         </button>
+                        {showApply && (
+                            <CharPopup onSubmit={handleApply} onClose={() => setShowApply(false)} />
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/common/Form/CharPopup.jsx
+++ b/src/components/common/Form/CharPopup.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+const vocations = ['Sorcerer', 'Druid', 'Knight', 'Paladin', 'Monk'];
+
+const CharPopup = ({ onSubmit, onClose }) => {
+    const [name, setName] = useState('');
+    const [level, setLevel] = useState('');
+    const [vocation, setVocation] = useState('');
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!name || !level || !vocation) return;
+        onSubmit({ name, level, vocation });
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-lg p-4 w-full max-w-sm text-black flex flex-col gap-4">
+                <h2 className="text-lg font-bold text-center">Informações do personagem</h2>
+                <input
+                    className="border p-2 rounded"
+                    placeholder="Nome do char"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+                <input
+                    className="border p-2 rounded"
+                    placeholder="Level"
+                    type="number"
+                    value={level}
+                    onChange={(e) => setLevel(e.target.value)}
+                />
+                <select
+                    className="border p-2 rounded"
+                    value={vocation}
+                    onChange={(e) => setVocation(e.target.value)}
+                >
+                    <option value="">Selecione a vocação</option>
+                    {vocations.map(v => (
+                        <option key={v} value={v}>{v}</option>
+                    ))}
+                </select>
+                <div className="flex justify-end gap-2">
+                    <button type="button" onClick={onClose} className="px-3 py-1 border rounded">Cancelar</button>
+                    <button type="submit" className="px-3 py-1 bg-[#A8C090] rounded">Confirmar</button>
+                </div>
+            </form>
+        </div>
+    );
+};
+
+export default CharPopup;

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -5,13 +5,16 @@ import { createAd, getAdsCreateToday } from '../../../firebase/firestoreService'
 import { Timestamp } from "firebase/firestore";
 import { AuthContext } from '../../../context/AuthContext';
 
-const Form = ({ onCreateAd, onWorldSelect }) => {
+const vocations = ['Sorcerer', 'Druid', 'Knight', 'Paladin', 'Monk'];
+
+const Form = ({ onCreateAd, onWorldSelect, charInfo }) => {
     const [creatures, setCreatures] = useState([]);
     const [soulCore, setSoulCore] = useState(null);
     const [inputValue, setInputValue] = useState('');
     const [world, setWorld] = useState('');
     const [worlds, setWorlds] = useState([]);
     const [showLimitPopup, setShowLimitPopup] = useState(false);
+    const [requireApproval, setRequireApproval] = useState(false);
 
     useEffect(() => {
         async function fetchCreatures() {
@@ -63,7 +66,7 @@ const Form = ({ onCreateAd, onWorldSelect }) => {
             return;
         }
 
-        const base = import.meta.env.BASE_URL;
+        if (!charInfo) return alert('Informe os dados do personagem');
 
         const newAd = {
             id: new Date().getTime(),
@@ -73,13 +76,9 @@ const Form = ({ onCreateAd, onWorldSelect }) => {
             value: inputValue || "A combinar",
             world,
             userId,
-            roles: [
-                { icon: `${base}roles/sorcerer-front.png`, current: 1, total: 1 },
-                { icon: `${base}roles/druid-front.png`, current: 0, total: 1 },
-                { icon: `${base}roles/knight-front.png`, current: 0, total: 1 },
-                { icon: `${base}roles/paladin-front.png`, current: 0, total: 1 },
-                { icon: `${base}roles/monk-front.png`, current: 0, total: 1 },
-            ],
+            approvalRequired: requireApproval,
+            party: [charInfo],
+            pending: [],
         };
 
         await createAd(newAd);
@@ -139,6 +138,15 @@ const Form = ({ onCreateAd, onWorldSelect }) => {
                     placeholder="Ex: 500k"
                     className="w-full p-2 rounded text-black"
                 />
+            </div>
+            <div className="flex items-center gap-2">
+                <input
+                    type="checkbox"
+                    id="approval-check"
+                    checked={requireApproval}
+                    onChange={(e) => setRequireApproval(e.target.checked)}
+                />
+                <label htmlFor="approval-check">Aprovar inscrições</label>
             </div>
             <button
                 type="submit"

--- a/src/firebase/firestoreService.js
+++ b/src/firebase/firestoreService.js
@@ -1,5 +1,5 @@
 import { db } from './firebase';
-import { collection, addDoc, getDocs, query, where, Timestamp, getFirestore } from 'firebase/firestore';
+import { collection, addDoc, getDocs, query, where, Timestamp, getFirestore, doc, updateDoc, arrayUnion } from 'firebase/firestore';
 
 export const createAd = async (adData) => {
     try {
@@ -43,3 +43,15 @@ export async function getAdsCreateToday(userId) {
         return 0;
     }
 }
+
+export const applyToAd = async (adId, charInfo, approvalRequired) => {
+    try {
+        const docRef = doc(db, 'bossAds', adId);
+        const field = approvalRequired ? 'pending' : 'party';
+        await updateDoc(docRef, {
+            [field]: arrayUnion(charInfo)
+        });
+    } catch (error) {
+        console.error('Erro ao aplicar para vaga:', error);
+    }
+};


### PR DESCRIPTION
## Summary
- add `CharPopup` for collecting character info
- integrate popup into ActionHub and Form
- store party data and approval flag when creating ads
- allow players to apply with character info via popup
- update Firestore service to add applicants

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b1adf0be08323835738375122ac00