### PR TITLE
Fix React card apply logic and firestore import

### DIFF
--- a/src/components/common/Card/Card.jsx
+++ b/src/components/common/Card/Card.jsx
@@ -35,13 +35,16 @@ const Card = ({ adData }) => {
 
     const handleApply = async (info) => {
         if (!user) return;
-        const success = await applyToAd(adData.id, { ...info, userId: user.uid }, adData.approvalRequired);
+        const success = await applyToAd(
+            adData.id,
+            { ...info, userId: user.uid },
+            adData.approvalRequired
+        );
+
         if (success && !adData.approvalRequired) {
             setParty(prev => [...prev, { ...info, userId: user.uid }]);
-        await applyToAd(adData.id, info, adData.approvalRequired);
-        if (!adData.approvalRequired) {
-            setParty(prev => [...prev, info]);
         }
+
         setShowApply(false);
     };
 
@@ -100,8 +103,6 @@ const Card = ({ adData }) => {
                             disabled={alreadyApplied}
                         >
                             {alreadyApplied ? 'Aplicado' : 'Aplicar'}
-                            className='w-full h-[30px] rounded-[8px] bg-[#A8C090] mt-auto text-black'>
-                            Aplicar
                         </button>
                         {showApply && (
                             <CharPopup onSubmit={handleApply} onClose={() => setShowApply(false)} />

--- a/src/firebase/firestoreService.js
+++ b/src/firebase/firestoreService.js
@@ -1,6 +1,5 @@
 import { db } from './firebase';
 import { collection, addDoc, getDocs, query, where, Timestamp, getFirestore, doc, updateDoc, arrayUnion, getDoc } from 'firebase/firestore';
-import { collection, addDoc, getDocs, query, where, Timestamp, getFirestore, doc, updateDoc, arrayUnion } from 'firebase/firestore';
 
 export const createAd = async (adData) => {
     try {
@@ -77,9 +76,4 @@ export const respondToApplication = async (adId, applicantId, accept) => {
     const updatedPending = pending.filter(p => p.userId !== applicantId);
     const updatedParty = accept ? [...(data.party || []), applicant] : (data.party || []);
     await updateDoc(docRef, { pending: updatedPending, party: updatedParty });
-};
-
-    } catch (error) {
-        console.error('Erro ao aplicar para vaga:', error);
-    }
 };


### PR DESCRIPTION
## Summary
- correct duplicate logic in Card apply handler
- simplify apply button markup
- remove duplicate import and extraneous code from firestore service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b25252e3c8323826a0e28436b4bb2