### PR TITLE
Fix ad ID bug and allow removing applications

### DIFF
--- a/src/components/common/Card/DetailsPopup.jsx
+++ b/src/components/common/Card/DetailsPopup.jsx
@@ -32,13 +32,13 @@ const DetailsPopup = ({ party, onClose, onApply, alreadyApplied }) => (
             </ul>
             <button
                 onClick={onApply}
-                disabled={alreadyApplied}
-                className="mt-4 w-full h-[30px] rounded-[8px] bg-[#A8C090] text-black disabled:opacity-50"
+                className={`mt-4 w-full h-[30px] rounded-[8px] text-black ${alreadyApplied ? 'bg-red-600' : 'bg-[#A8C090]'}`}
             >
-                {alreadyApplied ? 'Aplicado' : 'Aplicar'}
+                {alreadyApplied ? 'Remover' : 'Aplicar'}
             </button>
         </div>
     </div>
 );
 
 export default DetailsPopup;
+

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -72,7 +72,6 @@ const Form = ({ onCreateAd, onWorldSelect, charInfo, onCharInfoRequest }) => {
         }
 
         const newAd = {
-            id: new Date().getTime(),
             createdAt: Timestamp.now(),
             soulCoreName: soulCore.label,
             soulcoreImage: soulCore.image,
@@ -84,8 +83,9 @@ const Form = ({ onCreateAd, onWorldSelect, charInfo, onCharInfoRequest }) => {
             pending: [],
         };
 
-        await createAd(newAd);
-        onCreateAd(newAd);
+        const docId = await createAd(newAd);
+        const adWithId = { ...newAd, id: docId };
+        onCreateAd(adWithId);
 
         setSoulCore(null);
         setInputValue('');

--- a/src/firebase/firestoreService.js
+++ b/src/firebase/firestoreService.js
@@ -77,3 +77,20 @@ export const respondToApplication = async (adId, applicantId, accept) => {
     const updatedParty = accept ? [...(data.party || []), applicant] : (data.party || []);
     await updateDoc(docRef, { pending: updatedPending, party: updatedParty });
 };
+
+export const removeApplication = async (adId, userId) => {
+    try {
+        const docRef = doc(db, 'bossAds', adId);
+        const snap = await getDoc(docRef);
+        if (!snap.exists()) return false;
+        const data = snap.data();
+        const updatedParty = (data.party || []).filter(p => p.userId !== userId);
+        const updatedPending = (data.pending || []).filter(p => p.userId !== userId);
+        await updateDoc(docRef, { party: updatedParty, pending: updatedPending });
+        return true;
+    } catch (error) {
+        console.error('Erro ao remover aplicação:', error);
+        return false;
+    }
+};
+


### PR DESCRIPTION
## Summary
- fix new ad creation to store the firestore id
- add function to remove an application
- show `Remover` button when a user has already applied
- support pending list in cards and in the popup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c3544d97c832394202dac667800d1