### PR TITLE
Fix Firestore configuration

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -6,7 +6,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyD2jVbZrdx1C7svJ6FksiJ082UmLSXaeNQ",
   authDomain: "exiva-moe-res.firebaseapp.com",
   projectId: "exiva-moe-res",
-  storageBucket: "exiva-moe-res.firebasestorage.app",
+  storageBucket: "exiva-moe-res.appspot.com",
   messagingSenderId: "95259758584",
   appId: "1:95259758584:web:e20e7a3f7fedf9d721500d",
   measurementId: "G-XYK27376P9"

--- a/src/firebase/firestoreService.js
+++ b/src/firebase/firestoreService.js
@@ -1,5 +1,5 @@
 import { db } from './firebase';
-import { collection, addDoc, getDocs, query, where, Timestamp, getFirestore, doc, updateDoc, arrayUnion, getDoc } from 'firebase/firestore';
+import { collection, addDoc, getDocs, query, where, Timestamp, doc, updateDoc, arrayUnion, getDoc } from 'firebase/firestore';
 
 export const createAd = async (adData) => {
     try {
@@ -22,8 +22,7 @@ export const getAds = async () => {
 };
 
 export async function getAdsCreateToday(userId) {
-    const db = getFirestore();
-    const adsRef = collection(db, 'ads');
+    const adsRef = collection(db, 'bossAds');
 
     const startOfDay = new Date();
     startOfDay.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- correct Firestore collection name in `getAdsCreateToday`
- update Firebase storage bucket URL

## Testing
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c55d9c958832395e5a82c5cfa6e3c