### PR TITLE
Enforce soulcore apply limits

### DIFF
--- a/src/firebase/firestoreService.js
+++ b/src/firebase/firestoreService.js
@@ -50,9 +50,18 @@ export const applyToAd = async (adId, charInfo, approvalRequired) => {
         if (!snap.exists()) return false;
         const data = snap.data();
         const existing = [...(data.party || []), ...(data.pending || [])];
-        if (existing.some(p => p.userId === charInfo.userId)) {
+
+        // Impede inscrições duplicadas para o mesmo personagem ou usuário
+        if (existing.some(p => p.userId === charInfo.userId ||
+            (p.name && charInfo.name && p.name.toLowerCase() === charInfo.name.toLowerCase()))) {
             return false;
         }
+
+        // Limite máximo de 5 jogadores por soulcore (incluindo pendentes)
+        if (existing.length >= 5) {
+            return false;
+        }
+
         const field = approvalRequired ? 'pending' : 'party';
         await updateDoc(docRef, {
             [field]: arrayUnion(charInfo)


### PR DESCRIPTION
## Summary
- prevent duplicate characters per soulcore
- block more than 5 players per soulcore

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d25ae65b88323a895f61bcf763b24