### PR TITLE
Add ad application notifications

### DIFF
--- a/src/components/common/Notification/NotificationCenter.jsx
+++ b/src/components/common/Notification/NotificationCenter.jsx
@@ -1,0 +1,51 @@
+import React, { useContext } from 'react';
+import { NotificationContext } from '../../../context/NotificationContext';
+
+const NotificationCenter = () => {
+  const { notifications, respond, minimized, setMinimized } = useContext(NotificationContext);
+
+  if (minimized) {
+    return (
+      <button
+        onClick={() => setMinimized(false)}
+        className="fixed bottom-4 right-4 bg-accent text-white px-2 py-1 rounded z-50"
+      >
+        Mostrar notificações
+      </button>
+    );
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
+      <button
+        onClick={() => setMinimized(true)}
+        className="self-end text-white text-sm"
+      >
+        Minimizar
+      </button>
+      {notifications.map((n) => (
+        <div key={n.id} className="bg-white text-black p-3 rounded shadow-lg w-72 flex flex-col">
+          <p className="mb-2 text-sm">
+            O {n.applicant.name} solicitou uma vaga para o soulcore de {n.soulCoreName}.
+          </p>
+          <div className="flex gap-2 self-end">
+            <button
+              onClick={() => respond(n.adId, n.applicant.userId, true, n.id)}
+              className="px-2 py-1 bg-accent-green rounded"
+            >
+              Aceitar
+            </button>
+            <button
+              onClick={() => respond(n.adId, n.applicant.userId, false, n.id)}
+              className="px-2 py-1 bg-red-600 text-white rounded"
+            >
+              Recusar
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default NotificationCenter;

--- a/src/components/common/Notification/NotificationCenter.jsx
+++ b/src/components/common/Notification/NotificationCenter.jsx
@@ -25,7 +25,7 @@ const NotificationCenter = () => {
       </button>
       {notifications.map((n) => (
         <div key={n.id} className="bg-white text-black p-3 rounded shadow-lg w-72 flex flex-col">
-          <p className="mb-2 text-sm">
+          <p className="mb-2 text-sm text-black">
             O {n.applicant.name} solicitou uma vaga para o soulcore de {n.soulCoreName}.
           </p>
           <div className="flex gap-2 self-end">

--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { db } from '../firebase/firebase';
+import { respondToApplication } from '../firebase/firestoreService';
+import { AuthContext } from './AuthContext';
+import NotificationCenter from '../components/common/Notification/NotificationCenter';
+
+export const NotificationContext = createContext({
+  notifications: [],
+  respond: async () => {},
+  minimized: false,
+  setMinimized: () => {},
+});
+
+export const NotificationProvider = ({ children }) => {
+  const { user } = useContext(AuthContext);
+  const [notifications, setNotifications] = useState([]);
+  const [adsState, setAdsState] = useState({});
+  const [minimized, setMinimized] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    const q = query(collection(db, 'bossAds'), where('userId', '==', user.uid));
+    const unsub = onSnapshot(q, (snapshot) => {
+      snapshot.docChanges().forEach((change) => {
+        const docId = change.doc.id;
+        const data = change.doc.data();
+        const prev = adsState[docId] || { pending: [] };
+        const newPending = data.pending || [];
+        if (newPending.length > prev.pending.length) {
+          const added = newPending.filter(
+            (p) => !prev.pending.some((old) => old.userId === p.userId)
+          );
+          added.forEach((p) => {
+            setNotifications((n) => [
+              ...n,
+              {
+                id: `${docId}_${p.userId}`,
+                adId: docId,
+                applicant: p,
+                soulCoreName: data.soulCoreName,
+              },
+            ]);
+          });
+        }
+        adsState[docId] = { pending: newPending };
+        setAdsState({ ...adsState });
+      });
+    });
+    return () => unsub();
+  }, [user]);
+
+  const respond = async (adId, applicantId, accept, notifId) => {
+    await respondToApplication(adId, applicantId, accept);
+    setNotifications((n) => n.filter((notif) => notif.id !== notifId));
+  };
+
+  return (
+    <NotificationContext.Provider
+      value={{ notifications, respond, minimized, setMinimized }}
+    >
+      {children}
+      <NotificationCenter />
+    </NotificationContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
+import { NotificationProvider } from './context/NotificationContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <BrowserRouter>
     <AuthProvider>
-      <App />
+      <NotificationProvider>
+        <App />
+      </NotificationProvider>
     </AuthProvider>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- notify ad owners when players apply to their ads
- display notifications in a pop-up in the bottom-right corner
- allow accepting or rejecting directly from the pop-up
- wrap app with NotificationProvider

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686da9b50ee48323ad6d1b87e7f75720